### PR TITLE
chore: Support uv 0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ houou-logs = "houou_logs.cli:main"
 Repository = "https://github.com/Apricot-S/houou-logs.git"
 
 [build-system]
-requires = ["uv_build>=0.8.17,<0.9.0"]
+requires = ["uv_build>=0.8.17,<0.10.0"]
 build-backend = "uv_build"
 
 [dependency-groups]


### PR DESCRIPTION
uv 0.9.0 のリリースノートで uv_build には破壊的変更なしとされているため、0.9.X も許容する。