### PR TITLE
chore: Add Python 3.14 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "requests>=2.32.5,<3",


### PR DESCRIPTION
Python 3.14 が正式になったので追加する。
各コマンドが動作することは確認済み。