### PR TITLE
feat: complete validation

### DIFF
--- a/src/houou_logs/validate.py
+++ b/src/houou_logs/validate.py
@@ -70,6 +70,7 @@ def validate(db_path: Path) -> tuple[bool, int, int]:
 
     with closing(db.open_db(db_path)) as conn, conn:
         cursor = conn.cursor()
+        write_cursor = conn.cursor()
 
         num_ids = db.count_all_ids(cursor)
         num_logs = db.count_all_log_contents(cursor)
@@ -108,6 +109,6 @@ def validate(db_path: Path) -> tuple[bool, int, int]:
                 tqdm.write(
                     "Invalid log content detected. Reset to unprocessed.",
                 )
-                db.reset_log_content(cursor, log_id)
+                db.reset_log_content(write_cursor, log_id)
 
     return (were_errors, num_valid_logs, num_ids)


### PR DESCRIPTION
When `reset_log_content` calls `cursor.execute(...)` on the same `cursor`, it replaces the active SELECT result set, killing the iteration.

This uses `write_cursor` and leaves `cursor`'s iteration undisturbed so the loop continues through the rest of the database.

**Context**
Currently, `validate.py` will exit as soon as it hits any `was_error = true`. Thus making correction of a database very time-consuming, especially when the error is at the end of the database (tenhou's server is terribly slow and the process cannot be multi-threaded).

This should let `validate.py` completely validate the file and mark **ALL** `was_error = true` as unprocessed, saving validation time.