### PR TITLE
fix: pass headers to niquests session

### DIFF
--- a/src/houou_logs/session.py
+++ b/src/houou_logs/session.py
@@ -15,6 +15,4 @@ TIMEOUT = (
 
 
 def create_session() -> niquests.Session:
-    session = niquests.Session()
-    session.headers.update(HEADERS)
-    return session
+    return niquests.Session(headers=HEADERS)


### PR DESCRIPTION
niquests v3.19.0 での型の厳格化により既存コードが型エラーになった。
`Session` インスタンス作成時に `headers` を指定すれば型エラーにならないので修正する。